### PR TITLE
Added option `array-contents-only`

### DIFF
--- a/Pixie/CommandLineOptions/ParseOptions.cs
+++ b/Pixie/CommandLineOptions/ParseOptions.cs
@@ -5,8 +5,11 @@ namespace Pixie
     [Verb("parse", HelpText = "parses  a pattern filled with graphical font to a byte array")]
     internal class ParseOptions : CommonOptions
     {
-        [Option('s', "single-array", HelpText = "place all characters to single array")]
+        [Option('s', "single-array", HelpText = "place all characters into single array")]
         public bool SingleArray { get; set; }
+        
+        [Option( "array-contents-only", HelpText = "Omit single array name and curly braces, only produce array contents")]
+        public bool ArrayContentOnly { get; set; }
 
         [Value(0, HelpText = "image containing font bitmap", MetaName = "file name", Required = true)]
         public string InputFileName { get; set; }

--- a/Pixie/CommandLineOptions/ParseOptions.cs
+++ b/Pixie/CommandLineOptions/ParseOptions.cs
@@ -8,7 +8,7 @@ namespace Pixie
         [Option('s', "single-array", HelpText = "place all characters into single array")]
         public bool SingleArray { get; set; }
         
-        [Option( "array-contents-only", HelpText = "Omit single array name and curly braces, only produce array contents")]
+        [Option( 'a', "array-contents-only", HelpText = "Omit single array name and curly braces, only produce array contents")]
         public bool ArrayContentOnly { get; set; }
 
         [Value(0, HelpText = "image containing font bitmap", MetaName = "file name", Required = true)]

--- a/Pixie/OutputFileFormatter.cs
+++ b/Pixie/OutputFileFormatter.cs
@@ -20,7 +20,8 @@ namespace Pixie
         /// <param name="symbols">byte[] representation of symbols</param>
         /// <param name="fileName">path to the file to create</param>
         /// <param name="singleArray">shall output be written to single array or one array per symbol</param>
-        public static void WriteOutput(List<byte[]> symbols, string fileName, bool singleArray = false)
+        /// <param name="contentOnly">for single array: output will be just array contents, without name or curly braces</param>
+        public static void WriteOutput(List<byte[]> symbols, string fileName, bool singleArray = false, bool contentOnly = false)
         {
             try
             {
@@ -45,8 +46,15 @@ namespace Pixie
                         var totalLength = (from s in symbols
                             select s.Length).Sum();
 
-                        writer.Write($"unsigned char c[{totalLength}] = \n");
-                        writer.Write("{\n    ");
+                        if (contentOnly == false)
+                        {
+                            writer.Write($"unsigned char c[{totalLength}] = \n");
+                            writer.Write("{\n    ");
+                        }
+                        else
+                        {
+                            writer.Write("    ");
+                        }
 
                         int elementCounter = 0;
 
@@ -64,7 +72,12 @@ namespace Pixie
                                 }
                             }
                         }
-                        writer.Write("\n};");
+
+                        if (contentOnly == false)
+                        {
+                            writer.Write("\n};");
+                        }
+
                         writer.WriteLine("\n");
                     }
                     else

--- a/Pixie/Program.cs
+++ b/Pixie/Program.cs
@@ -76,7 +76,7 @@ namespace Pixie
                 var bitmap = new Bitmap(Image.FromFile(options.InputFileName));
                 var mapper = new PixelMapper(bitmap, Settings);
                 var map = mapper.MapPixels(options.SkipHeaders);
-                OutputFileFormatter.WriteOutput(map, options.OutputFileName, options.SingleArray);
+                OutputFileFormatter.WriteOutput(map, options.OutputFileName, options.SingleArray, options.ArrayContentOnly);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This will enable including output.h directly in the user code, kinda like:

``` cpp
uint8_t my_super_font[] = 
{
    #include "output.h"
}
```

That's easier than copy-pasting or assigning custom name/namespace to generated header.